### PR TITLE
Allow input and output file types to differ

### DIFF
--- a/namelist.sealevel
+++ b/namelist.sealevel
@@ -16,7 +16,8 @@
 /
 &file_format
     ext =''
-    fType = 'text'
+     fType_in = 'text'
+     fType_out = 'both'
 
 /
 &file_name

--- a/sl_model_mod.f90
+++ b/sl_model_mod.f90
@@ -113,7 +113,6 @@ module sl_model_mod
    integer :: counti, countf,countrate                         ! Computation timing
    real :: counti_cpu, countf_cpu
    type(sphere) :: spheredat                                   ! SH transform data to be passed to subroutines
-   integer :: unit_num
 
    ! For Jerry's code to read in Love numbers
    integer :: legord(norder),nmod(norder),nmodes(norder),ll,nm,np
@@ -161,7 +160,7 @@ module sl_model_mod
    subroutine sl_call_readnl
 
       call sl_readnl(inputfolder_ice, inputfolder, planetfolder, gridfolder, &
-                        outputfolder, outputfolder_ice, folder_coupled, ext, fType, &
+                        outputfolder, outputfolder_ice, folder_coupled, ext, fType_in, fType_out, &
                         planetmodel, icemodel, icemodel_out, timearray, &
                         topomodel, topo_initial, grid_lat, grid_lon, &
                         checkmarine, tpw, calcRG, input_times, &

--- a/user_specs_mod.f90
+++ b/user_specs_mod.f90
@@ -61,6 +61,7 @@ module user_specs_mod
    !  not used if the sea-level model (SLM) is not coupled to an ice sheet model (ISM)
 
    integer, parameter :: str_len = 200
+   integer :: unit_num
 
    ! Input directory
    character(str_len) :: inputfolder_ice  = 'INPUT_FILES/icemodel/'
@@ -79,9 +80,10 @@ module user_specs_mod
    ! Since the code does not explicitly specify the precision (single or double) of the input/output files, an 
    !  extension could be used to designate the type. Alternatively, the files could also be delimited text files (to 
    !  be implemented later). Specify the common extension here (applicable to the names of ALL input/output files): 
-   character(4) :: ext = ''       ! '.sgl' | '.dbl' | '.txt' | '.nc' if fType == 'binary'
+   character(4) :: ext = ''       ! '.sgl' | '.dbl' | '.txt' | '.nc' if fType == 'netcdf'
    ! ... and their file type:
-   character(6) :: fType = 'text'  ! 'binary' | 'text' | empty quote '' for both binary and text format
+   character(6) :: fType_in  = 'text'  ! 'netcdf' | 'text'
+   character(6) :: fType_out = 'text'  ! 'netcdf' | 'text' | 'both' for both netcdf and text format
    
    ! Various selection ================================================================================================!
    character(5)  :: whichplanet   = 'earth'                    ! e.g. 'earth', 'Mars', etc.


### PR DESCRIPTION
This merge replaces fType with fType_in and fType_out, so that the
input and output file types can differ (e.g. text files for input and
netcdf for output).