### PR TITLE
Fix random occurrences of code hanging and floating point exceptions

### DIFF
--- a/sl_init_mod.f90
+++ b/sl_init_mod.f90
@@ -65,7 +65,7 @@ end module planets_mod
 !=====================================================================================netCDF I/O mod===!
 module sl_io_mod
 !-------------------------------------------------------------------------------------------------------
-   use user_specs_mod, only: nglv, ext, fType_in, fType_out, outputfolder, gridfolder, grid_lat, grid_lon, unit_num
+   use user_specs_mod, only: nglv, ext, fType_in, fType_out, outputfolder, gridfolder, grid_lat, grid_lon, unit_num, str_len
    use netCDF
    implicit none
 
@@ -81,7 +81,7 @@ module sl_io_mod
          print *, trim(nf90_strerror(status))
          print *, "NetCDF I/O error occurred in the Sea Level Model."
          print *, "Backtrace of calling routines:"
-         CALL BACKTRACE
+         !CALL BACKTRACE
          stop "Stopping Sea Level Model."
       endif
 
@@ -329,26 +329,26 @@ module sl_io_mod
                         dt3, dt4, Ldt1, Ldt2, &
                         Ldt3, Ldt4, whichplanet)
 
-      character(*), intent(out) :: inputfolder_ice
-      character(*), intent(out) :: inputfolder
-      character(*), intent(out) :: planetfolder
-      character(*), intent(out) :: gridfolder
-      character(*), intent(out) :: outputfolder
-      character(*), intent(out) :: outputfolder_ice
-      character(*), intent(out) :: folder_coupled
+      character(str_len), intent(out) :: inputfolder_ice
+      character(str_len), intent(out) :: inputfolder
+      character(str_len), intent(out) :: planetfolder
+      character(str_len), intent(out) :: gridfolder
+      character(str_len), intent(out) :: outputfolder
+      character(str_len), intent(out) :: outputfolder_ice
+      character(str_len), intent(out) :: folder_coupled
 
-      character(*), intent(out) :: ext
-      character(*), intent(out) :: fType_in
-      character(*), intent(out) :: fType_out
+      character(4), intent(out) :: ext
+      character(6), intent(out) :: fType_in
+      character(6), intent(out) :: fType_out
 
-      character(*), intent(out) :: planetmodel
-      character(*), intent(out) :: icemodel
-      character(*), intent(out) :: icemodel_out
-      character(*), intent(out) :: timearray
-      character(*), intent(out) :: topomodel
-      character(*), intent(out) :: topo_initial
-      character(*), intent(out) :: grid_lat
-      character(*), intent(out) :: grid_lon
+      character(str_len), intent(out) :: planetmodel
+      character(str_len), intent(out) :: icemodel
+      character(str_len), intent(out) :: icemodel_out
+      character(str_len), intent(out) :: timearray
+      character(str_len), intent(out) :: topomodel
+      character(str_len), intent(out) :: topo_initial
+      character(str_len), intent(out) :: grid_lat
+      character(str_len), intent(out) :: grid_lon
 
       logical, intent(out)  :: checkmarine
       logical, intent(out)  :: tpw
@@ -369,7 +369,7 @@ module sl_io_mod
       integer, intent(out)  :: Ldt3
       integer, intent(out)  :: Ldt4
 
-      character(*), intent(out) :: whichplanet
+      character(5), intent(out) :: whichplanet
 
       namelist /io_directory/ inputfolder_ice, inputfolder, &
                               planetfolder, gridfolder, &

--- a/sl_model_mod.f90
+++ b/sl_model_mod.f90
@@ -907,18 +907,12 @@ module sl_model_mod
       write(unit_num,'(A,EN15.4E2,A)') '                     ',times(nfiles),' years'
 
       ! Decompose initial topography (STEP 2) (used to check convergence of outer loop)
-      write(unit_num,'(A)') '!!! Calling spat2spec on initial topo !!!'
-      flush(unit_num)
       call spat2spec(tinit(:,:), t0lm, spheredat)
-      write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
-      flush(unit_num)
 
       !=====================================================================================
       !                   1. BEGIN ICE PART
       !=====================================================================================
 
-      write(unit_num,'(A)') '======SLM Starting Ice Part '
-      flush(unit_num)
       ! Read in ice loads and compute the difference in iceload over each time interval
       do n=1, nfiles
          ! Calculate icestar (STEP 3) (eq.43)
@@ -938,17 +932,9 @@ module sl_model_mod
                enddo
             enddo
             ! Decompose ice field
-            write(unit_num,'(A)') '!!! Calling spat2spec on ice field !!!'
-            flush(unit_num)
             call spat2spec(icestarxy(:,:),icestarlm(:,:),spheredat)
-            write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
-            flush(unit_num)
          else ! If not checking for floating ice
-            write(unit_num,'(A)') '!!! Calling spat2spec on ice field, not checking floating ice!!!'
-            flush(unit_num)
             call spat2spec(icexy(:,:,n),icestarlm(:,:),spheredat) ! Decompose ice field
-            write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
-            flush(unit_num)
          endif
 
          if (n == 1) then
@@ -968,8 +954,6 @@ module sl_model_mod
       !                            BEGIN OCEAN PART
       !========================================================================================
 
-      write(unit_num,'(A)') '======SLM Starting Ocean Part '
-      flush(unit_num)
       ! Calculate beta (STEP 3) (eq. 44)
       ! Calculate current beta based on iceload at the current timestep
       do j = 1, 2 * nglv
@@ -986,19 +970,11 @@ module sl_model_mod
       cstar0(:,:)  = cxy0(:,:) * beta0(:,:)
       cstarxy(:,:) = cxy(:,:) * beta(:,:)  ! First guess to the O.F using converged O.F the preivous timestep
 
-      write(unit_num,'(A)') '!!! Calling spat2spec on cstar !!!'
-      flush(unit_num)
       call spat2spec(cstarxy,cstarlm,spheredat) ! Decompose the current cstar
-      write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
-      flush(unit_num)
 
       ! Calculate the first guess to topography correction
       tOxy(:,:) = tinit(:,:) * (cstarxy(:,:) - cstar0(:,:)) ! (eq. 70)
-      write(unit_num,'(A)') '!!! Calling spat2spec on topo correction !!!'
-      flush(unit_num)
       call spat2spec(tOxy, tOlm, spheredat) ! Decompose the topo correction term
-      write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
-      flush(unit_num)
 
 
       dS(:,:,1) = deltaS(:,:,1)
@@ -1023,8 +999,6 @@ module sl_model_mod
       !----------------------------------------------------------------------------------------
       ninner = 1
       do ! Inner loop
-         write(unit_num,'(A,I4)') '======SLM Inner Loop #: ', ninner
-         flush(unit_num)
 
          !-----\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/    Rotation    \/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/----!
 
@@ -1065,8 +1039,6 @@ module sl_model_mod
 
             dm(:,nfiles) = mm(:) - oldm(:)
 
-         write(unit_num,'(A)') '!!! calculate lambda !!!'
-         flush(unit_num)
             ! Calculate lambda (rotational driving) from m (Milne and Mitrovica 1998)
             lambda(0,0) = (radius**2 * omega**2 / 3.0) * ((mm(1)**2 + mm(2)**2 + mm(3)**2) + 2.0 * mm(3))
             lambda(2,0) = (radius**2 * omega**2 / (6.0 * sqrt(5.0))) &
@@ -1095,8 +1067,6 @@ module sl_model_mod
                dsl_rot(2,m) = (ekhTE * (deltalambda(2,m,nfiles-1) + dlambda(2,m,nfiles)) + viscoustt) / gacc ! (eq. B28/B25)
             enddo
 
-         write(unit_num,'(A)') '!!! calcRG !!!'
-         flush(unit_num)
             if (calcRG) then ! For R calculations
                rr_rot(:,:) = (0.0,0.0)
                do nn = 1,nfiles-1 ! Sum over all previous timesteps
@@ -1121,8 +1091,6 @@ module sl_model_mod
             rr_rot(:,:) = (0.0,0.0)
          endif ! TPW
 
-         write(unit_num,'(A)') '!!! End rotation !!!'
-         flush(unit_num)
          !-----/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\    End Rotation    /\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\----!
 
          ! Calculate beta (eq. B14) - viscous response factor
@@ -1149,8 +1117,6 @@ module sl_model_mod
             enddo
          endif
 
-         write(unit_num,'(A)') '!!! Compute viscous !!!'
-         flush(unit_num)
          ! Compute viscous response outside inner loop, since it doesn't depend on current timestep
          viscous(:,:) = (0.0,0.0)
          do l = 1,norder
@@ -1161,8 +1127,6 @@ module sl_model_mod
             enddo
          enddo
 
-         write(unit_num,'(A)') '!!! STEP 6 !!!'
-         flush(unit_num)
          ! Calculate change in sea level from change in load (STEP 6)
          dsllm(:,:) = (0.0,0.0) ! No change on first timestep
          do l = 1,norder
@@ -1175,25 +1139,15 @@ module sl_model_mod
             enddo
          enddo
 
-         write(unit_num,'(A)') '!!! Add rotational effects !!!'
-         flush(unit_num)
          ! Add rotational effects (calculated above)
          dsllm(0:2,0:2) = dsllm(0:2,0:2) + dsl_rot(0:2,0:2)
 
          ! Convert dSL (total spatially heterogeneous change since time0) to spatial domain
-         write(unit_num,'(A)') '!!! Calling spat2spec on dSL!!!'
-         flush(unit_num)
          call spec2spat(dslxy, dsllm, spheredat)
-         write(unit_num,'(A)') '!!! Returned from spat2spec !!!'
-         flush(unit_num)
 
          ! Compute r0 (STEP 7)
          rOxy(:,:) = dslxy(:,:) * cstarxy(:,:) ! (eq. 68)
-         write(unit_num,'(A)') '!!! Calling spat2spec !!!'
-         flush(unit_num)
          call spat2spec(rOxy, rOlm, spheredat) ! Decompose r0
-         write(unit_num,'(A)') '!!! Returned from spat2spec !!!'
-         flush(unit_num)
 
          ! Compute conservation term (STEP 8)
          conserv = (1 / cstarlm(0,0)) * (-1.0 * (rhoi / rhow) * deltaicestar(0,0,nfiles) - rOlm(0,0) + tOlm(0,0)) ! (eq. 78)
@@ -1207,11 +1161,7 @@ module sl_model_mod
           ! Update the total sea-level change up to the current time step
          deltasllm(:,:) = dsllm(:,:) ! Spatially heterogeneous component
          deltasllm(0,0) = deltasllm(0,0) + conserv ! Add uniform conservation term to (0,0)
-         write(unit_num,'(A)') '!!! Calling spec2spat !!!'
-         flush(unit_num)
          call spec2spat(deltaslxy, deltasllm, spheredat) ! Synthesize deltasl
-         write(unit_num,'(A)') '!!! Returned from spec2spat !!!'
-         flush(unit_num)
 
          ! Calculate convergence criterion for inner loop
          if ( abs(sum(abs(dSlm)) - sum(abs(olddSlm))) < epsilon(0.0) .and. abs(sum(abs(olddSlm))) < epsilon(0.0)) then
@@ -1240,23 +1190,13 @@ module sl_model_mod
 
             !new guess to ocean*beta function
             cstarxy(:,:) = cxy(:,:) * beta(:,:) ! (eq. 65)
-            write(unit_num,'(A)') '!!! Calling spat2spec for cstar !!!'
-            flush(unit_num)
             call spat2spec(cstarxy, cstarlm, spheredat) ! Decompose cstar
-            write(unit_num,'(A)') '!!! Returned from spat2spec for cstar!!!'
-            flush(unit_num)
 
             ! new guess to the topo correction
             tOxy(:,:) = tinit * (cstarxy(:,:) - cstar0(:,:)) ! (eq. 70)
-            write(unit_num,'(A)') '!!! Calling spec2spat topo corr !!!'
-            flush(unit_num)
             call spat2spec(tOxy, tOlm, spheredat) ! Decompose tO
-            write(unit_num,'(A)') '!!! Returned from spec2spat topo corr !!!'
-            flush(unit_num)
          endif
 
-         write(unit_num,'(A,ES15.3)') 'Inner loop iteration complete, xi=', xi
-         flush(unit_num)
          if (xi <= epsilon1) then ! If converged
             exit
          elseif (ninner == 9999) then ! If no convergence after a huge number of iterations

--- a/sl_model_mod.f90
+++ b/sl_model_mod.f90
@@ -232,7 +232,11 @@ module sl_model_mod
 
       ! allocate dimensions to arrays
       allocate (mask(ncalls+1),iceload(ncalls+1),icefiles(ncalls+1))
+      mask(:) = 0
+      iceload(:) = 0
+      icefiles(:) = 0
       allocate (TIMEWINDOW(TW_nfiles))
+      TIMEWINDOW(:)=0
 
       ! Initialize and grow the time window when t>0 but Travel == 0
       ! initialize the mask array and icefile numbers for the timewindow
@@ -327,6 +331,23 @@ module sl_model_mod
       allocate (dil(3,3,nfiles), dlambda(0:2,0:2,TW_nfiles),deltalambda(0:2,0:2,nfiles))
       allocate (dm(3,nfiles))
 
+      times = 0.0
+      lovebetatt = 0.0
+      lovebetattrr = 0.0
+      lovebetarr = 0.0
+      lovebeta = 0.0
+      icexy = 0.0
+      sl = 0.0
+      dS = 0.0
+      deltaS = 0.0
+      dicestar = 0.0
+      deltaicestar = 0.0
+      rr = 0.0
+      gg = 0.0
+      dil = 0.0
+      dlambda = 0.0
+      deltalambda = 0.0
+      dm = 0.0
 
       !!!!!!!!!!!!!!!!!!!ATTENTION!!!!!!!!
       ! TIMEWINDOW = TIMEWINDOW+1

--- a/sl_model_mod.f90
+++ b/sl_model_mod.f90
@@ -443,8 +443,6 @@ module sl_model_mod
       write(unit_num,*) 'nmelt=0, INITIALIZING THE SEA LEVEL MODEL..'
       flush(unit_num)
 
-      write(unit_num,*) "shape(t0lm),size,  norder", shape(t0lm), size(t0lm), norder
-
       !initialize variables
       j = TIMEWINDOW(1) ! initial file number (i.e. 0)
       write(unit_num,'(A,I4)') 'initial file number:', j
@@ -620,13 +618,8 @@ module sl_model_mod
             enddo
                   ! Decompose ice field
             call spat2spec(icestarxy(:,:),icestarlm(:,:),spheredat)
-      write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
-      call checkout(icestarlm)
          else ! If not checking for floating ice
             call spat2spec(icexy(:,:,1),icestarlm(:,:),spheredat) ! Decompose ice field
-      write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
-      call checkout(icestarlm)
-!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(icestarlm), maxval(icestarlm)
          endif
 
          ice_volume = icestarlm(0,0)*4*pi*radius**2
@@ -918,8 +911,6 @@ module sl_model_mod
       flush(unit_num)
       call spat2spec(tinit(:,:), t0lm, spheredat)
       write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
-      call checkout(t0lm)
-!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(t0lm), maxval(t0lm)
       flush(unit_num)
 
       !=====================================================================================
@@ -951,16 +942,12 @@ module sl_model_mod
             flush(unit_num)
             call spat2spec(icestarxy(:,:),icestarlm(:,:),spheredat)
             write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
-      call checkout(icestarlm)
-!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(icestarlm), maxval(icestarlm)
             flush(unit_num)
          else ! If not checking for floating ice
             write(unit_num,'(A)') '!!! Calling spat2spec on ice field, not checking floating ice!!!'
             flush(unit_num)
             call spat2spec(icexy(:,:,n),icestarlm(:,:),spheredat) ! Decompose ice field
             write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
-      call checkout(icestarlm)
-!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(icestarlm), maxval(icestarlm)
             flush(unit_num)
          endif
 
@@ -1002,9 +989,7 @@ module sl_model_mod
       write(unit_num,'(A)') '!!! Calling spat2spec on cstar !!!'
       flush(unit_num)
       call spat2spec(cstarxy,cstarlm,spheredat) ! Decompose the current cstar
-!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(cstarlm), maxval(cstarlm)
       write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
-      call checkout(cstarlm)
       flush(unit_num)
 
       ! Calculate the first guess to topography correction
@@ -1013,8 +998,6 @@ module sl_model_mod
       flush(unit_num)
       call spat2spec(tOxy, tOlm, spheredat) ! Decompose the topo correction term
       write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
-      call checkout(tOlm)
-!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(tOlm), maxval(tOlm)
       flush(unit_num)
 
 
@@ -1056,8 +1039,6 @@ module sl_model_mod
 
             dil(:,:,nfiles) = il(:,:) - oldil(:,:)
 
-         write(unit_num,'(A)') '!!! calculate m !!!'
-         flush(unit_num)
             ! Calculate m (rotation vector perturbation)
             !  - From Jerry's written notes, also Mitrovica, Wahr, Matsuyama, and Paulson (2005) eq. 2
             sum_il(:,:) = 0.0
@@ -1075,8 +1056,6 @@ module sl_model_mod
                sum_m(:) = sum_m(:) + dm(:,nn) * betattprime
             enddo
 
-         write(unit_num,'(A)') '!!! calculate m complete !!!'
-         flush(unit_num)
             do i = 1,2
                mm(i) = (1 / (1 - kTE(2) / kf)) * &
                      & ( (1 / (moiC - moiA)) * ((1 + kE(2)) * il(i,3) + sum_il(i,3)) + (1 / kf) * sum_m(i) )
@@ -1087,7 +1066,6 @@ module sl_model_mod
             dm(:,nfiles) = mm(:) - oldm(:)
 
          write(unit_num,'(A)') '!!! calculate lambda !!!'
-         call checkout3(deltalambda)
          flush(unit_num)
             ! Calculate lambda (rotational driving) from m (Milne and Mitrovica 1998)
             lambda(0,0) = (radius**2 * omega**2 / 3.0) * ((mm(1)**2 + mm(2)**2 + mm(3)**2) + 2.0 * mm(3))
@@ -1095,13 +1073,9 @@ module sl_model_mod
                         & * (mm(1)**2 + mm(2)**2 - 2.0 * mm(3)**2 - 4.0 * mm(3))
             lambda(2,1) = (radius**2 * omega**2 / sqrt(30.0)) * ((mm(1) - ii * mm(2)) * (1.0 + mm(3)))
             lambda(2,2) = (radius**2 * omega**2 / sqrt(5.0 * 24.0)) * (mm(2)**2 - mm(1)**2 + 2.0 * ii * mm(1) * mm(2))
-    call checkout(lambda)
-         call checkout3(dlambda)
-         flush(unit_num)
+
             dlambda(:,:,nfiles) = lambda(:,:) - deltalambda(:,:,nfiles-1)
 
-         write(unit_num,'(A)') '!!! calculate Kendall !!!'
-         flush(unit_num)
             ! Calculate effect on sea level (Love numbers) (Kendall)
             dsl_rot(:,:) = (0.0,0.0)
             ekhTE = 1 + kTE(2) - hTE(2)
@@ -1113,8 +1087,6 @@ module sl_model_mod
                enddo
             enddo
 
-         write(unit_num,'(A)') '!!! calculate dsl_rot !!!'
-         flush(unit_num)
             do m = 0,2
                viscoustt = (0.0,0.0)
                do nn = 1,nfiles-1 ! Sum the loads over all previous timesteps to get the sum on the 4th line of eq. B28
@@ -1178,10 +1150,6 @@ module sl_model_mod
          endif
 
          write(unit_num,'(A)') '!!! Compute viscous !!!'
-         call checkout(viscous)
-         call checkoutr(lovebeta)
-         call checkout3(dicestar)
-         call checkout3(dS)
          flush(unit_num)
          ! Compute viscous response outside inner loop, since it doesn't depend on current timestep
          viscous(:,:) = (0.0,0.0)
@@ -1217,8 +1185,6 @@ module sl_model_mod
          flush(unit_num)
          call spec2spat(dslxy, dsllm, spheredat)
          write(unit_num,'(A)') '!!! Returned from spat2spec !!!'
-      call checkout(dsllm)
-!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(dsllm), maxval(dsllm)
          flush(unit_num)
 
          ! Compute r0 (STEP 7)
@@ -1227,8 +1193,6 @@ module sl_model_mod
          flush(unit_num)
          call spat2spec(rOxy, rOlm, spheredat) ! Decompose r0
          write(unit_num,'(A)') '!!! Returned from spat2spec !!!'
-      call checkout(rOlm)
-!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(rOlm), maxval(rOlm)
          flush(unit_num)
 
          ! Compute conservation term (STEP 8)
@@ -1247,7 +1211,6 @@ module sl_model_mod
          flush(unit_num)
          call spec2spat(deltaslxy, deltasllm, spheredat) ! Synthesize deltasl
          write(unit_num,'(A)') '!!! Returned from spec2spat !!!'
-!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(deltasllm), maxval(deltasllm)
          flush(unit_num)
 
          ! Calculate convergence criterion for inner loop
@@ -1281,8 +1244,6 @@ module sl_model_mod
             flush(unit_num)
             call spat2spec(cstarxy, cstarlm, spheredat) ! Decompose cstar
             write(unit_num,'(A)') '!!! Returned from spat2spec for cstar!!!'
-      call checkout(cstarlm)
-!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(cstarlm), maxval(cstarlm)
             flush(unit_num)
 
             ! new guess to the topo correction
@@ -1291,8 +1252,6 @@ module sl_model_mod
             flush(unit_num)
             call spat2spec(tOxy, tOlm, spheredat) ! Decompose tO
             write(unit_num,'(A)') '!!! Returned from spec2spat topo corr !!!'
-      call checkout(tOlm)
-!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(tOlm), maxval(tOlm)
             flush(unit_num)
          endif
 
@@ -1352,8 +1311,6 @@ module sl_model_mod
          endif
          rrlm(0:2,0:2) = rrlm(0:2,0:2) + rr_rot(0:2,0:2)
          call spec2spat(rrxy, rrlm, spheredat)
-            write(unit_num,'(A)') '!!! Returned from spec2spat 1314 !!'
-!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(rrlm), maxval(rrlm)
          rr(:,:,nfiles) = rrxy(:,:)
       endif
 
@@ -1474,17 +1431,6 @@ module sl_model_mod
 
 !----------------------------------------------------------------------------------------------------------------------!
 
-   subroutine checkOutR(i)
-      real,dimension(:,:), intent(in) :: i
-      write(unit_num,'(A,ES15.3, ES15.3,ES15.3, ES15.3)') ' Return min/max, real/imag: ', minval(real(i)), maxval(real(i))
-   end subroutine
-   subroutine checkOut(i)
-      complex,dimension(:,:), intent(in) :: i
-      write(unit_num,'(A,ES15.3, ES15.3,ES15.3, ES15.3)') ' Return min/max, real/imag: ', minval(real(i)), maxval(real(i)), minval(AIMAG(i)), maxval(AIMAG(i))
-   end subroutine
-   subroutine checkOut3(i)
-      complex,dimension(:,:,:), intent(in) :: i
-      write(unit_num,'(A,ES15.3, ES15.3,ES15.3, ES15.3)') ' Return min/max, real/imag: ', minval(real(i)), maxval(real(i)), minval(AIMAG(i)), maxval(AIMAG(i))
-   end subroutine
+
 
 end module sl_model_mod

--- a/sl_model_mod.f90
+++ b/sl_model_mod.f90
@@ -443,6 +443,8 @@ module sl_model_mod
       write(unit_num,*) 'nmelt=0, INITIALIZING THE SEA LEVEL MODEL..'
       flush(unit_num)
 
+      write(unit_num,*) "shape(t0lm),size,  norder", shape(t0lm), size(t0lm), norder
+
       !initialize variables
       j = TIMEWINDOW(1) ! initial file number (i.e. 0)
       write(unit_num,'(A,I4)') 'initial file number:', j
@@ -618,8 +620,13 @@ module sl_model_mod
             enddo
                   ! Decompose ice field
             call spat2spec(icestarxy(:,:),icestarlm(:,:),spheredat)
+      write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
+      call checkout(icestarlm)
          else ! If not checking for floating ice
             call spat2spec(icexy(:,:,1),icestarlm(:,:),spheredat) ! Decompose ice field
+      write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
+      call checkout(icestarlm)
+!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(icestarlm), maxval(icestarlm)
          endif
 
          ice_volume = icestarlm(0,0)*4*pi*radius**2
@@ -911,6 +918,8 @@ module sl_model_mod
       flush(unit_num)
       call spat2spec(tinit(:,:), t0lm, spheredat)
       write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
+      call checkout(t0lm)
+!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(t0lm), maxval(t0lm)
       flush(unit_num)
 
       !=====================================================================================
@@ -942,12 +951,16 @@ module sl_model_mod
             flush(unit_num)
             call spat2spec(icestarxy(:,:),icestarlm(:,:),spheredat)
             write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
+      call checkout(icestarlm)
+!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(icestarlm), maxval(icestarlm)
             flush(unit_num)
          else ! If not checking for floating ice
             write(unit_num,'(A)') '!!! Calling spat2spec on ice field, not checking floating ice!!!'
             flush(unit_num)
             call spat2spec(icexy(:,:,n),icestarlm(:,:),spheredat) ! Decompose ice field
             write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
+      call checkout(icestarlm)
+!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(icestarlm), maxval(icestarlm)
             flush(unit_num)
          endif
 
@@ -989,7 +1002,9 @@ module sl_model_mod
       write(unit_num,'(A)') '!!! Calling spat2spec on cstar !!!'
       flush(unit_num)
       call spat2spec(cstarxy,cstarlm,spheredat) ! Decompose the current cstar
+!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(cstarlm), maxval(cstarlm)
       write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
+      call checkout(cstarlm)
       flush(unit_num)
 
       ! Calculate the first guess to topography correction
@@ -998,6 +1013,8 @@ module sl_model_mod
       flush(unit_num)
       call spat2spec(tOxy, tOlm, spheredat) ! Decompose the topo correction term
       write(unit_num,'(A)') '!!! returned from  spat2spec !!!'
+      call checkout(tOlm)
+!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(tOlm), maxval(tOlm)
       flush(unit_num)
 
 
@@ -1039,6 +1056,8 @@ module sl_model_mod
 
             dil(:,:,nfiles) = il(:,:) - oldil(:,:)
 
+         write(unit_num,'(A)') '!!! calculate m !!!'
+         flush(unit_num)
             ! Calculate m (rotation vector perturbation)
             !  - From Jerry's written notes, also Mitrovica, Wahr, Matsuyama, and Paulson (2005) eq. 2
             sum_il(:,:) = 0.0
@@ -1056,6 +1075,8 @@ module sl_model_mod
                sum_m(:) = sum_m(:) + dm(:,nn) * betattprime
             enddo
 
+         write(unit_num,'(A)') '!!! calculate m complete !!!'
+         flush(unit_num)
             do i = 1,2
                mm(i) = (1 / (1 - kTE(2) / kf)) * &
                      & ( (1 / (moiC - moiA)) * ((1 + kE(2)) * il(i,3) + sum_il(i,3)) + (1 / kf) * sum_m(i) )
@@ -1066,6 +1087,7 @@ module sl_model_mod
             dm(:,nfiles) = mm(:) - oldm(:)
 
          write(unit_num,'(A)') '!!! calculate lambda !!!'
+         call checkout3(deltalambda)
          flush(unit_num)
             ! Calculate lambda (rotational driving) from m (Milne and Mitrovica 1998)
             lambda(0,0) = (radius**2 * omega**2 / 3.0) * ((mm(1)**2 + mm(2)**2 + mm(3)**2) + 2.0 * mm(3))
@@ -1073,9 +1095,13 @@ module sl_model_mod
                         & * (mm(1)**2 + mm(2)**2 - 2.0 * mm(3)**2 - 4.0 * mm(3))
             lambda(2,1) = (radius**2 * omega**2 / sqrt(30.0)) * ((mm(1) - ii * mm(2)) * (1.0 + mm(3)))
             lambda(2,2) = (radius**2 * omega**2 / sqrt(5.0 * 24.0)) * (mm(2)**2 - mm(1)**2 + 2.0 * ii * mm(1) * mm(2))
-
+    call checkout(lambda)
+         call checkout3(dlambda)
+         flush(unit_num)
             dlambda(:,:,nfiles) = lambda(:,:) - deltalambda(:,:,nfiles-1)
 
+         write(unit_num,'(A)') '!!! calculate Kendall !!!'
+         flush(unit_num)
             ! Calculate effect on sea level (Love numbers) (Kendall)
             dsl_rot(:,:) = (0.0,0.0)
             ekhTE = 1 + kTE(2) - hTE(2)
@@ -1087,6 +1113,8 @@ module sl_model_mod
                enddo
             enddo
 
+         write(unit_num,'(A)') '!!! calculate dsl_rot !!!'
+         flush(unit_num)
             do m = 0,2
                viscoustt = (0.0,0.0)
                do nn = 1,nfiles-1 ! Sum the loads over all previous timesteps to get the sum on the 4th line of eq. B28
@@ -1150,6 +1178,10 @@ module sl_model_mod
          endif
 
          write(unit_num,'(A)') '!!! Compute viscous !!!'
+         call checkout(viscous)
+         call checkoutr(lovebeta)
+         call checkout3(dicestar)
+         call checkout3(dS)
          flush(unit_num)
          ! Compute viscous response outside inner loop, since it doesn't depend on current timestep
          viscous(:,:) = (0.0,0.0)
@@ -1185,6 +1217,8 @@ module sl_model_mod
          flush(unit_num)
          call spec2spat(dslxy, dsllm, spheredat)
          write(unit_num,'(A)') '!!! Returned from spat2spec !!!'
+      call checkout(dsllm)
+!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(dsllm), maxval(dsllm)
          flush(unit_num)
 
          ! Compute r0 (STEP 7)
@@ -1193,6 +1227,8 @@ module sl_model_mod
          flush(unit_num)
          call spat2spec(rOxy, rOlm, spheredat) ! Decompose r0
          write(unit_num,'(A)') '!!! Returned from spat2spec !!!'
+      call checkout(rOlm)
+!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(rOlm), maxval(rOlm)
          flush(unit_num)
 
          ! Compute conservation term (STEP 8)
@@ -1211,6 +1247,7 @@ module sl_model_mod
          flush(unit_num)
          call spec2spat(deltaslxy, deltasllm, spheredat) ! Synthesize deltasl
          write(unit_num,'(A)') '!!! Returned from spec2spat !!!'
+!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(deltasllm), maxval(deltasllm)
          flush(unit_num)
 
          ! Calculate convergence criterion for inner loop
@@ -1244,6 +1281,8 @@ module sl_model_mod
             flush(unit_num)
             call spat2spec(cstarxy, cstarlm, spheredat) ! Decompose cstar
             write(unit_num,'(A)') '!!! Returned from spat2spec for cstar!!!'
+      call checkout(cstarlm)
+!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(cstarlm), maxval(cstarlm)
             flush(unit_num)
 
             ! new guess to the topo correction
@@ -1252,6 +1291,8 @@ module sl_model_mod
             flush(unit_num)
             call spat2spec(tOxy, tOlm, spheredat) ! Decompose tO
             write(unit_num,'(A)') '!!! Returned from spec2spat topo corr !!!'
+      call checkout(tOlm)
+!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(tOlm), maxval(tOlm)
             flush(unit_num)
          endif
 
@@ -1311,6 +1352,8 @@ module sl_model_mod
          endif
          rrlm(0:2,0:2) = rrlm(0:2,0:2) + rr_rot(0:2,0:2)
          call spec2spat(rrxy, rrlm, spheredat)
+            write(unit_num,'(A)') '!!! Returned from spec2spat 1314 !!'
+!            write(unit_num,'(A,ES15.3, ES15.3)') ' Return min/max: ', minval(rrlm), maxval(rrlm)
          rr(:,:,nfiles) = rrxy(:,:)
       endif
 
@@ -1431,6 +1474,17 @@ module sl_model_mod
 
 !----------------------------------------------------------------------------------------------------------------------!
 
-
+   subroutine checkOutR(i)
+      real,dimension(:,:), intent(in) :: i
+      write(unit_num,'(A,ES15.3, ES15.3,ES15.3, ES15.3)') ' Return min/max, real/imag: ', minval(real(i)), maxval(real(i))
+   end subroutine
+   subroutine checkOut(i)
+      complex,dimension(:,:), intent(in) :: i
+      write(unit_num,'(A,ES15.3, ES15.3,ES15.3, ES15.3)') ' Return min/max, real/imag: ', minval(real(i)), maxval(real(i)), minval(AIMAG(i)), maxval(AIMAG(i))
+   end subroutine
+   subroutine checkOut3(i)
+      complex,dimension(:,:,:), intent(in) :: i
+      write(unit_num,'(A,ES15.3, ES15.3,ES15.3, ES15.3)') ' Return min/max, real/imag: ', minval(real(i)), maxval(real(i)), minval(AIMAG(i)), maxval(AIMAG(i))
+   end subroutine
 
 end module sl_model_mod

--- a/spharmt.f90
+++ b/spharmt.f90
@@ -1663,8 +1663,8 @@ module spharmt
 
  subroutine vpassm (a,b,c,d,trigs,inc1,inc2,inc3,inc4,lot,n,ifac,la)
     integer, intent(in)  :: inc1, inc2, inc3, inc4, lot, n, ifac, la
-    real,    intent(in)  :: a(n),b(n),trigs(n)
-    real,    intent(out) :: c(n),d(n)
+    real,    intent(in)  :: a(n*(2*n+2)),b(n*(2*n+2)),trigs(n*(2*n+2))
+    real,    intent(out) :: c(n*(2*n+2)),d(n*(2*n+2))
 !
 !     subroutine "vpassm" - multiple version of "vpassa"
 !     performs one pass through data


### PR DESCRIPTION
This merge fixes issues that were causing the code to hang on large, complex configurations when coupled to MALI.  The most important change was to initialize allocatable arrays immediately after allocating them.  There was also a necessary change to the spharmt library to get it to run in debug mode without giving an array out of bounds error.   Finally, there was a chance to get the code to compile with intel.  There are a couple additional commits with tons of debugging messages that were kept in the history but reverted.