### PR TITLE
Make constants consistent with mali and others

### DIFF
--- a/sl_init_mod.f90
+++ b/sl_init_mod.f90
@@ -26,7 +26,7 @@ module planets_mod
    ! -------------------------------------------------------------------------
    subroutine earth_init
 
-      radius = 6.371E6              ! Radius of the Earth (m)
+      radius = 6.371229E6              ! Radius of the Earth (m)
       mass = 5.976E24               ! Mass of the Earth (kg)
       rhoi = 910.0                  ! Density of ice (kg/m^3)
       rhow = 1000.0                 ! Density of fresh water (kg/m^3)

--- a/sl_init_mod.f90
+++ b/sl_init_mod.f90
@@ -28,7 +28,7 @@ module planets_mod
 
       radius = 6.371E6              ! Radius of the Earth (m)
       mass = 5.976E24               ! Mass of the Earth (kg)
-      rhoi = 920.0                  ! Density of ice (kg/m^3)
+      rhoi = 910.0                  ! Density of ice (kg/m^3)
       rhow = 1000.0                 ! Density of fresh water (kg/m^3)
       gacc = 9.80665                ! Acceleration due to gravity at the Earth's surface (m/s^2)
       omega = 7.292e-5              ! Rotation rate of the Earth (rad/s)

--- a/sl_model_mod.f90
+++ b/sl_model_mod.f90
@@ -136,7 +136,6 @@ module sl_model_mod
    character(16) :: carg(20)                               ! Arguments from a bash script
    character(3) :: skip                                    ! variable used to skip lines in reading TPW file
 
-
    contains
 
    !======================================================================================================================!
@@ -501,6 +500,14 @@ module sl_model_mod
           enddo
 
           ! merge intitial topography with bedrock provided by the ice sheet model.
+          if (patch_ice) then
+             do j = 1,2*nglv
+                do i = 1,nglv
+                   icexy(i,j,nfiles) = 0.0
+                enddo
+             enddo
+          endif
+
           do j = 1,2*nglv
              do i = 1,nglv
                 icexy(i,j,nfiles) = mali_iceload(i,j) + icexy(i,j,nfiles)*(1 - mali_mask(i,j))
@@ -509,7 +516,6 @@ module sl_model_mod
 
           !write out the current ice load as a new file to the sea-level model ice folder
           call write_sl(icexy(:,:,nfiles), icemodel_out, outputfolder_ice, suffix=numstr)
-
       endif ! end if (coupling)
 
       !write out the initial topo of the simulation, tinit_0
@@ -694,6 +700,14 @@ module sl_model_mod
 
             ! ice thickness at the current time step inside the ISM domain is provided by the ISM
             ! merge iceload configuration
+            if (patch_ice) then
+               do j = 1,2*nglv
+                  do i = 1,nglv
+                     icexy(i,j,nfiles) = 0.0
+                  enddo
+               enddo
+            endif
+
             do j = 1,2*nglv
                do i = 1,nglv
                   icexy(i,j,nfiles) = mali_iceload(i,j) + icexy(i,j,nfiles)*(1 - mali_mask(i,j))


### PR DESCRIPTION
Previously the constant values for ice density and Earth radius used in the sea-level model were inconsistent with those used by MALI.  This PR makes the constant values consistent between the SLM and MALI. 

In addition, the PR includes another commit that adds an option called `patch_ice` that allows zero-ing out ice thickness outside the MALI domain when SLM and MALI are coupled. This option is useful when the input global ice thickness files read in by the SLM have non-zero ice thickness outside of the MALI domain (e.g., Greenland) but the user doesn't want to consider ice thickness outside the MALI domain. 

Test results are the following (*note that the executable for this test run was based off the MALI branch (https://github.com/MALI-Dev/E3SM/pull/83), which is pending to be merged yet (as of July 21st, 2023):
1. Ice volume calculated with `patch_ice` turned **off**:
Ice mass seen by the SLM is much greater than the ice volume seen by MALI because it considers both the Greenland ice Sheet already defined in the global ice thickness file with the Antarctic Ice Sheet passed onto the SLM by MALI. 
![image](https://github.com/MALI-Dev/1DSeaLevelModel_FWTW/assets/33441196/c822d23c-4243-48f6-b0a7-2d61fa1200ae)

2. Ice volume calculated with `patch_ice` turned **on**:
Ice volume seen by the SLM matches with the area-distortion-corrected (i.e. "scaled for the k-factor") MALI ice mass. 
![image](https://github.com/MALI-Dev/1DSeaLevelModel_FWTW/assets/33441196/27448f7e-c4ac-4a33-a94b-3d3598e3b290)

