### PR TITLE
Change model res parameters `nglv` and `norder` as namelist options

### DIFF
--- a/namelist.sealevel
+++ b/namelist.sealevel
@@ -4,6 +4,11 @@
     dt1 = 5
 
 /
+&model_resolution
+    norder = 512
+    nglv = 512
+
+/
 &io_directory
     inputfolder_ice = 'INPUT_FILES/icemodel/'
     inputfolder = 'INPUT_FILES/others/'

--- a/sl_init_mod.f90
+++ b/sl_init_mod.f90
@@ -89,16 +89,15 @@ module sl_io_mod
 
 
    ! -------------------------------------------------------------------------
-   subroutine read_sl(data_slm, filename, filepath, nglv, suffix, fext)
+   subroutine read_sl(data_slm, filename, filepath, suffix, fext)
       character (len = *), intent (in) :: filename, filepath
-      integer, intent(in) :: nglv
       real, dimension(:,:), intent(inout) :: data_slm
       character (len = *), optional :: suffix, fext
 
       if (fType_in == 'text') then
-         call read_txt(data_slm, filename, filepath, nglv, suffix, fext)
+         call read_txt(data_slm, filename, filepath, suffix, fext)
       elseif (fType_in == 'netcdf') then
-         call read_nf90(data_slm, filename, filepath, nglv, suffix, fext)
+         call read_nf90(data_slm, filename, filepath, suffix, fext)
       else
          write(unit_num,*) "Error: fType_in should be one of 'netcdf' or 'text'"
          stop
@@ -108,17 +107,16 @@ module sl_io_mod
 
 
    ! -------------------------------------------------------------------------
-   subroutine write_sl(data_slm, filename, filepath, nglv, suffix, fext)
+   subroutine write_sl(data_slm, filename, filepath, suffix, fext)
       character (len = *), intent (in) :: filename, filepath
-      integer, intent(in) :: nglv
       real, dimension(:,:), intent(in) :: data_slm
       character (len = *), optional :: suffix, fext
 
       if ((fType_out == 'text') .or. (fType_out == 'both')) then
-         call write_txt(data_slm, filename, filepath, nglv, suffix, fext)
+         call write_txt(data_slm, filename, filepath, suffix, fext)
       endif
       if ((fType_out == 'netcdf') .or. (fType_out == 'both')) then
-         call write_nf90(data_slm, filename, filepath, nglv, suffix, fext='.nc')
+         call write_nf90(data_slm, filename, filepath, suffix, fext='.nc')
       endif
       if ((fType_out /= 'netcdf') .and. (fType_out /= 'text') .and. (fType_out /= 'both')) then
          write(unit_num,*) "Error: fType_out should be one of 'netcdf', 'text', or 'both'"
@@ -129,9 +127,8 @@ module sl_io_mod
 
 
    ! -------------------------------------------------------------------------
-   subroutine write_nf90(data_slm, filename, filepath, nglv, suffix, fext)
+   subroutine write_nf90(data_slm, filename, filepath, suffix, fext)
 
-      integer, intent(in) :: nglv
       character (len = *), intent(in) :: filename, filepath
       integer :: ncid, varid, lat_varid, lon_varid, lat_dimid, lon_dimid
       integer, dimension(2) :: dimids
@@ -204,10 +201,9 @@ module sl_io_mod
 
 
    ! -------------------------------------------------------------------------
-   subroutine read_nf90(data_slm, filename, filepath, nglv, suffix, fext)
+   subroutine read_nf90(data_slm, filename, filepath, suffix, fext)
 
       character (len = *), intent(in) :: filename, filepath !file name and path
-      integer, intent(in) :: nglv
       real, dimension(:,:), allocatable :: data_temp !temp. variable name in the SLM in which nc data will be stored
       real, dimension(:,:), intent(out) :: data_slm
       character (len = *), optional ::  suffix
@@ -243,9 +239,8 @@ module sl_io_mod
 
 
    ! -------------------------------------------------------------------------
-   subroutine check_ncFile(ncvar, slmvar, varname, nglv)
+   subroutine check_ncFile(ncvar, slmvar, varname)
 
-      integer, intent(in) :: nglv
       real, dimension(:,:), intent(in) :: ncvar, slmvar
       character (len = *), intent(in) :: varname
 
@@ -259,8 +254,7 @@ module sl_io_mod
 
 
    ! -------------------------------------------------------------------------
-   subroutine write_txt(data_slm, filename, filepath, nglv, suffix, fext)
-      integer, intent(in) :: nglv
+   subroutine write_txt(data_slm, filename, filepath, suffix, fext)
       real, dimension(:,:), intent(in) :: data_slm
       character (len = *), intent(in) :: filename, filepath
       character (len = *), optional :: fext, suffix
@@ -285,9 +279,8 @@ module sl_io_mod
 
 
    ! -------------------------------------------------------------------------
-   subroutine read_txt(data_slm, filename, filepath, nglv, suffix, fext)
+   subroutine read_txt(data_slm, filename, filepath, suffix, fext)
 
-      integer, intent(in) :: nglv
       real, dimension(:,:), intent(inout) :: data_slm
       character (len = *), intent(in) :: filename, filepath
       character (len = *), optional :: fext, suffix

--- a/sl_init_mod.f90
+++ b/sl_init_mod.f90
@@ -325,7 +325,7 @@ module sl_io_mod
                         grid_lat, grid_lon, checkmarine, &
                         tpw, calcRG, input_times, &
                         initial_topo, iceVolume, coupling, &
-                        patch_ice, L_sim, dt1, dt2, &
+                        patch_ice, norder, nglv, L_sim, dt1, dt2, &
                         dt3, dt4, Ldt1, Ldt2, &
                         Ldt3, Ldt4, whichplanet)
 
@@ -359,6 +359,8 @@ module sl_io_mod
       logical, intent(out)  :: coupling
       logical, intent(out)  :: patch_ice
 
+      integer, intent(out)  :: norder
+      integer, intent(out)  :: nglv
       integer, intent(out)  :: L_sim
       integer, intent(out)  :: dt1
       integer, intent(out)  :: dt2

--- a/sl_init_mod.f90
+++ b/sl_init_mod.f90
@@ -92,7 +92,7 @@ module sl_io_mod
    subroutine read_sl(data_slm, filename, filepath, nglv, suffix, fext)
       character (len = *), intent (in) :: filename, filepath
       integer, intent(in) :: nglv
-      real, dimension(nglv,2*nglv), intent(inout) :: data_slm
+      real, dimension(:,:), intent(inout) :: data_slm
       character (len = *), optional :: suffix, fext
 
       if (fType_in == 'text') then
@@ -111,7 +111,7 @@ module sl_io_mod
    subroutine write_sl(data_slm, filename, filepath, nglv, suffix, fext)
       character (len = *), intent (in) :: filename, filepath
       integer, intent(in) :: nglv
-      real, dimension(nglv,2*nglv), intent(in) :: data_slm
+      real, dimension(:,:), intent(in) :: data_slm
       character (len = *), optional :: suffix, fext
 
       if ((fType_out == 'text') .or. (fType_out == 'both')) then
@@ -135,11 +135,15 @@ module sl_io_mod
       character (len = *), intent(in) :: filename, filepath
       integer :: ncid, varid, lat_varid, lon_varid, lat_dimid, lon_dimid
       integer, dimension(2) :: dimids
-      real, dimension(nglv,2*nglv), intent(in) :: data_slm !data in the SLM written to the netCDF file
+      real, dimension(:,:), intent(in) :: data_slm !data in the SLM written to the netCDF file
       character (len = *), optional ::  suffix
       character (len = *), optional :: fext
-      real, dimension(nglv)        :: latgrid
-      real, dimension(2*nglv)      :: longrid
+      real, dimension(:), allocatable :: latgrid
+      real, dimension(:), allocatable :: longrid
+
+      allocate (latgrid(nglv), longrid(2*nglv))
+      latgrid = 0.0
+      longrid = 0.0
 
       ! attribute IDs for I/O in netCDF
       !character (len = *), parameter :: UNITS = "units"
@@ -204,11 +208,14 @@ module sl_io_mod
 
       character (len = *), intent(in) :: filename, filepath !file name and path
       integer, intent(in) :: nglv
-      real, dimension(2*nglv,nglv) :: data_temp !temp. variable name in the SLM in which nc data will be stored
-      real, dimension(nglv,2*nglv), intent(out) :: data_slm
+      real, dimension(:,:), allocatable :: data_temp !temp. variable name in the SLM in which nc data will be stored
+      real, dimension(:,:), intent(out) :: data_slm
       character (len = *), optional ::  suffix
       character (len = *), optional :: fext
       integer :: ncid, varid
+
+      allocate (data_temp(2*nglv,nglv))
+      data_temp = 0.0
 
       !open the file
       if (present (suffix)) then
@@ -239,7 +246,7 @@ module sl_io_mod
    subroutine check_ncFile(ncvar, slmvar, varname, nglv)
 
       integer, intent(in) :: nglv
-      real, dimension(nglv,2*nglv), intent(in) :: ncvar, slmvar
+      real, dimension(:,:), intent(in) :: ncvar, slmvar
       character (len = *), intent(in) :: varname
 
       if (sum(sum(ncvar, dim=1))-sum(sum(slmvar,dim=1)) .NE.0) then
@@ -254,7 +261,7 @@ module sl_io_mod
    ! -------------------------------------------------------------------------
    subroutine write_txt(data_slm, filename, filepath, nglv, suffix, fext)
       integer, intent(in) :: nglv
-   real, dimension(nglv,2*nglv), intent(in) :: data_slm
+      real, dimension(:,:), intent(in) :: data_slm
       character (len = *), intent(in) :: filename, filepath
       character (len = *), optional :: fext, suffix
 
@@ -281,7 +288,7 @@ module sl_io_mod
    subroutine read_txt(data_slm, filename, filepath, nglv, suffix, fext)
 
       integer, intent(in) :: nglv
-   real, dimension(nglv,2*nglv) :: data_slm
+      real, dimension(:,:), intent(inout) :: data_slm
       character (len = *), intent(in) :: filename, filepath
       character (len = *), optional :: fext, suffix
 

--- a/sl_init_mod.f90
+++ b/sl_init_mod.f90
@@ -94,8 +94,7 @@ module sl_io_mod
       integer, intent(in) :: nglv
       real, dimension(nglv,2*nglv), intent(inout) :: data_slm
       character (len = *), optional :: suffix, fext
-      write(unit_num,*) 'HHHHHH nglv seen in the read_sl subroutine sl_init_io module is ', nglv
-      write(unit_num,*) 'HHHHHH size of the data_slm is', size(data_slm), filename
+
       if (fType_in == 'text') then
          call read_txt(data_slm, filename, filepath, nglv, suffix, fext)
       elseif (fType_in == 'netcdf') then
@@ -114,8 +113,7 @@ module sl_io_mod
       integer, intent(in) :: nglv
       real, dimension(nglv,2*nglv), intent(in) :: data_slm
       character (len = *), optional :: suffix, fext
-      write(unit_num,*) 'HHHHHH nglv seen in the write_sl subroutine sl_init_io module is ', nglv
-      write(unit_num,*) 'HHHHHH size of the data_slm is', size(data_slm), filename
+
       if ((fType_out == 'text') .or. (fType_out == 'both')) then
          call write_txt(data_slm, filename, filepath, nglv, suffix, fext)
       endif
@@ -391,7 +389,6 @@ module sl_io_mod
       integer, intent(out)  :: Ldt4
 
       character(5), intent(out) :: whichplanet
-
 
       namelist /io_directory/ inputfolder_ice, inputfolder, &
                               planetfolder, gridfolder, &

--- a/sl_init_mod.f90
+++ b/sl_init_mod.f90
@@ -197,6 +197,8 @@ module sl_io_mod
       call check( nf90_put_var(ncid, lat_varid, latgrid))
       call check( nf90_close(ncid))
 
+      deallocate (latgrid, longrid)
+
    end subroutine write_nf90
 
 
@@ -234,6 +236,8 @@ module sl_io_mod
       call check( nf90_get_var(ncid, varid, data_temp) ) ! read the data
       call check( nf90_close(ncid) ) ! close the file
       data_slm = reshape(data_temp,[nglv,2*nglv])
+
+      deallocate (data_temp)
 
    end subroutine read_nf90
 

--- a/sl_model_driver.f90
+++ b/sl_model_driver.f90
@@ -21,6 +21,7 @@ if (nargs == 4) then ! Check if namelist file is provided
    read (carg(2),*) iter      ! the coupling time step we are on (in years)
    read (carg(3),*) dtime     ! coupling time (in years)
    read (carg(4),*) starttime ! start time of the simulation (in years)
+
 elseif (nargs == 5) then
    call sl_drive_readnl(itersl, dtime, starttime)
    read (carg(2),*) iter

--- a/sl_model_driver.f90
+++ b/sl_model_driver.f90
@@ -21,7 +21,6 @@ if (nargs == 4) then ! Check if namelist file is provided
    read (carg(2),*) iter      ! the coupling time step we are on (in years)
    read (carg(3),*) dtime     ! coupling time (in years)
    read (carg(4),*) starttime ! start time of the simulation (in years)
-
 elseif (nargs == 5) then
    call sl_drive_readnl(itersl, dtime, starttime)
    read (carg(2),*) iter

--- a/sl_model_driver.f90
+++ b/sl_model_driver.f90
@@ -37,6 +37,9 @@ call sl_solver_checkpoint(itersl, dtime)
 ! set up the temporal resolution
 call sl_timewindow(iter)
 
+! initialize arrays
+call sl_allocate_and_initialize_array
+
 ! intialize and execute the sea-level solver
 if (iter .eq. 0) then
    call sl_solver_init(itersl, starttime)
@@ -44,4 +47,6 @@ elseif (iter .gt. 0) then
    call sl_solver(itersl, iter, dtime, starttime)
 endif
 
+! deallocate arrays
+call sl_deallocate_array
 end program sl_model_driver

--- a/sl_model_mod.f90
+++ b/sl_model_mod.f90
@@ -319,8 +319,6 @@ module sl_model_mod
          write(unit_num,'(A,I4,A)') '   ', Travel_total - Travel, ' more TW steps to march!'
       endif
 
-      write(unit_num,*) 'HHHHH norder and nglv seen in the sl_timedow module', norder, nglv
-
       !!!!!!!!!!!!!!!!!!!ATTENTION!!!!!!!!
       ! TIMEWINDOW = TIMEWINDOW+1
       ! TIMEWINDOW = -(TIMEWINDOW*100+starttime)
@@ -339,7 +337,6 @@ module sl_model_mod
    !=======================================================================================================================!
    subroutine sl_allocate_and_initialize_array
 
-      write(unit_num,*) 'HHHH sl_allocate_and_initialize_array is seeing norder and nglv as', norder, nglv
       allocate (tinit_0(nglv,2*nglv), tinit_0_last(nglv,2*nglv), pred_pres_topo(nglv,2*nglv), &
                 init_topo_corr(nglv,2*nglv), truetopo(nglv,2*nglv), glw_matrix(nglv,2*nglv), &
                 slcxy_ocn(nglv,2*nglv), slcxy_ocnBeta(nglv,2*nglv), deltaslxy(nglv,2*nglv), &
@@ -548,7 +545,7 @@ module sl_model_mod
 
       ! set up the planet profile
       call set_planet
-      write(unit_num,*) 'HHHH initializing spharmt in sl_solver_checkpoint, norder and nglv values are:', norder, nglv
+
       ! initalize spherical harmonics
       call spharmt_init(spheredat, 2*nglv, nglv, norder, radius) ! Initialize spheredat (for SH transform subroutines)
 
@@ -570,7 +567,7 @@ module sl_model_mod
       write(unit_num,*) 'nmelt=0, INITIALIZING THE SEA LEVEL MODEL..'
       flush(unit_num)
 
-      write(unit_num,*) 'HH in sl_solver init: Number of orders and degree of spherical harmonics is ', norder
+      write(unit_num,*) 'Number of orders and degree of spherical harmonics is ', norder
       write(unit_num,*) 'The number of Gauss-Legendre nodes in latitude(nglv): ', nglv
 
       !initialize variables
@@ -620,8 +617,6 @@ module sl_model_mod
        endif
 
        if (coupling) then  !if coupling the ICE SHEET - SEA LEVEL MODELs
-          write(unit_num,*) '====HHHHH sice of mali_iceload, mali_bedrock, mali_mask',size(mali_iceload),size(mali_bedrock),size(mali_mask)
-          !allocate (mali_iceload(nglv,2*nglv), mali_bedrock(nglv,2*nglv), mali_mask(nglv,2*nglv))
           write(unit_num,*) 'Merge initial topography and iceload with the ISM data'
 
           ! merge intitial topography with bedrock provided by the ice sheet model.
@@ -630,7 +625,6 @@ module sl_model_mod
                 tinit_0(i,j) = mali_bedrock(i,j) + tinit_0(i,j)*(1 - mali_mask(i,j))
              enddo
           enddo
-          write(unit_num,*) '===HHH: MALI mask shape in sl_solver:', size(mali_mask)
           ! merge intitial topography with bedrock provided by the ice sheet model.
           if (patch_ice) then
              do j = 1,2*nglv

--- a/sl_model_mod.f90
+++ b/sl_model_mod.f90
@@ -582,16 +582,16 @@ module sl_model_mod
 
       !====================== topography and ice load========================
       ! read in the initial iceload from the coupled ice input folder
-      call read_sl(icexy(:,:,1), icemodel, inputfolder_ice, nglv, suffix=numstr)
+      call read_sl(icexy(:,:,1), icemodel, inputfolder_ice, suffix=numstr)
       !  Initialize topography (STEP 1)
       if (initial_topo) then
          write(unit_num,*) 'Reading in initial topo file'
-         call read_sl(tinit_0, topo_initial, inputfolder, nglv)
+         call read_sl(tinit_0, topo_initial, inputfolder)
       else  ! if initial topo is unknown
 
          ! Present-day observed topography
          write(unit_num,*) 'Reading in ETOPO2 file'
-         call read_sl(truetopo, topomodel, inputfolder, nglv)
+         call read_sl(truetopo, topomodel, inputfolder)
 
          ! if topography is not iteratively getting improved, or if at the first loop of outer-iteration
          if (itersl == 1) then
@@ -605,10 +605,10 @@ module sl_model_mod
              write(iterstr,'(I2)') itersl-1
              iterstr = trim(adjustl(iterstr))
 
-             call read_sl(pred_pres_topo, 'pred_pres_topo_', outputfolder, nglv, suffix=iterstr)
+             call read_sl(pred_pres_topo, 'pred_pres_topo_', outputfolder, suffix=iterstr)
 
              ! read in tinit_0 from the previous outer-iteration 'itersl-1'
-             call read_sl(tinit_0_last, 'tgrid0_', outputfolder, nglv, suffix=iterstr)
+             call read_sl(tinit_0_last, 'tgrid0_', outputfolder, suffix=iterstr)
 
              ! compute topography correction for the initial topography
              init_topo_corr(:,:) = truetopo(:,:) - pred_pres_topo(:,:)
@@ -641,11 +641,11 @@ module sl_model_mod
           enddo
 
           !write out the current ice load as a new file to the sea-level model ice folder
-          call write_sl(icexy(:,:,nfiles), icemodel_out, outputfolder_ice, nglv, suffix=numstr)
+          call write_sl(icexy(:,:,nfiles), icemodel_out, outputfolder_ice, suffix=numstr)
       endif ! end if (coupling)
 
       !write out the initial topo of the simulation, tinit_0
-      call write_sl(tinit_0(:,:), 'tgrid', outputfolder, nglv, suffix=numstr)
+      call write_sl(tinit_0(:,:), 'tgrid', outputfolder, suffix=numstr)
 
 
       !========================== ocean function =========================
@@ -661,7 +661,7 @@ module sl_model_mod
       enddo
 
       !  write out the initial ocean function as a file
-      call write_sl(cxy0(:,:), 'ocean', outputfolder, nglv, suffix=numstr)
+      call write_sl(cxy0(:,:), 'ocean', outputfolder, suffix=numstr)
 
       ! write out the ocean area
       call spat2spec(cxy0, clm, spheredat)
@@ -683,7 +683,7 @@ module sl_model_mod
       enddo
 
       !  write out the initial beta function as a file
-      call write_sl(beta0(:,:), 'beta', outputfolder, nglv, suffix=numstr)
+      call write_sl(beta0(:,:), 'beta', outputfolder, suffix=numstr)
 
       ! write out the ocean area excluding the marine-based region
       cstarxy(:,:) = cxy0(:,:) * beta0(:,:)
@@ -838,7 +838,7 @@ module sl_model_mod
                numstr = trim(adjustl(numstr))
 
               ! read in ice files (upto the previous time step) from the sea-level model folder
-              call read_sl(icexy(:,:,n), icemodel_out, outputfolder_ice, nglv, suffix=numstr)
+              call read_sl(icexy(:,:,n), icemodel_out, outputfolder_ice, suffix=numstr)
 
             enddo
 
@@ -848,7 +848,7 @@ module sl_model_mod
             numstr = trim(adjustl(numstr))
 
             ! read in ice thickness at the current time step outside the ISM domain from 'inputfolder_ice'
-            call read_sl(icexy(:,:,nfiles), icemodel, inputfolder_ice, nglv, suffix=numstr)
+            call read_sl(icexy(:,:,nfiles), icemodel, inputfolder_ice, suffix=numstr)
 
             ! ice thickness at the current time step inside the ISM domain is provided by the ISM
             ! merge iceload configuration
@@ -874,7 +874,7 @@ module sl_model_mod
             write(numstr,'(I6)') j
             numstr = trim(adjustl(numstr))
             ! read in ice files (upto the previous time step) from the sea-level model folder
-            call read_sl(icexy(:,:,n), icemodel, inputfolder_ice, nglv, suffix=numstr)
+            call read_sl(icexy(:,:,n), icemodel, inputfolder_ice, suffix=numstr)
          enddo
 
       endif !endif coupling
@@ -901,7 +901,7 @@ module sl_model_mod
 
       !Read in the initial topography (topo at the beginning of the full simulation)
       !This is used to output the total sea level change from the beginning of the simulation
-      call read_sl(tinit_0, 'tgrid0', outputfolder, nglv)
+      call read_sl(tinit_0, 'tgrid0', outputfolder)
 
       j = TIMEWINDOW(1) ! first element of the time window as the initial file
       write(unit_num,'(A,I4)') 'file number of the first item in the TW:', j
@@ -909,14 +909,14 @@ module sl_model_mod
       numstr = trim(adjustl(numstr))
 
       ! read in initial (first file within the time window) ocean function
-      call read_sl(cxy0(:,:), 'ocean', outputfolder, nglv, suffix=numstr)
+      call read_sl(cxy0(:,:), 'ocean', outputfolder, suffix=numstr)
 
       if (nmelt == 1) then
          cxy(:,:) = cxy0(:,:)
       endif
 
       ! read in initial (first file within the time window) beta
-      call read_sl(beta0(:,:), 'beta', outputfolder, nglv, suffix=numstr)
+      call read_sl(beta0(:,:), 'beta', outputfolder, suffix=numstr)
 
       if (tpw) then
          ! initialize empty arrays
@@ -961,7 +961,7 @@ module sl_model_mod
       numstr2 = trim(adjustl(numstr2))
 
       ! read in topography of the previous timestep
-      call read_sl(topoxy_m1(:,:), 'tgrid', outputfolder, nglv, suffix=numstr2)
+      call read_sl(topoxy_m1(:,:), 'tgrid', outputfolder, suffix=numstr2)
 
       ! condition for time window travel
       if (Travel.EQ.0) then
@@ -973,7 +973,7 @@ module sl_model_mod
          write(numstr,'(I4)') j
          numstr = trim(adjustl(numstr))
 
-        call read_sl(tinit(:,:), 'tgrid', outputfolder, nglv, suffix=numstr)
+        call read_sl(tinit(:,:), 'tgrid', outputfolder, suffix=numstr)
       endif
       !endif nmelt>0
 
@@ -985,7 +985,7 @@ module sl_model_mod
          numstr = trim(adjustl(numstr))
 
          ! read in converged ocean function from the last timestep
-         call read_sl(cxy(:,:), 'ocean', outputfolder, nglv, suffix=numstr)
+         call read_sl(cxy(:,:), 'ocean', outputfolder, suffix=numstr)
 
          ! if there has been more than one melting episode
          ! read in the total ocean loading computed from previous timesteps 0 to nmelt minus 1.
@@ -1458,13 +1458,13 @@ module sl_model_mod
       endif
 
       ! topography at the current timestep
-      call write_sl(topoxy, 'tgrid', outputfolder, nglv, suffix=numstr)
+      call write_sl(topoxy, 'tgrid', outputfolder, suffix=numstr)
 
       ! converged ocean function at the current timestep
-      call write_sl(cxy, 'ocean', outputfolder, nglv, suffix=numstr)
+      call write_sl(cxy, 'ocean', outputfolder, suffix=numstr)
 
       ! converged beta function at the current timestpe
-      call write_sl(beta, 'beta', outputfolder, nglv, suffix=numstr)
+      call write_sl(beta, 'beta', outputfolder, suffix=numstr)
 
       ! output the ocean areas
       open(unit = 201, file = trim(outputfolder)//'ocean_area', form = 'formatted', access ='sequential', &
@@ -1509,28 +1509,28 @@ module sl_model_mod
          write(unit_num,*) 'Last time step of the simulation! writing out files for next outer-iteration loop'
 
          ! write out the predicted present day topography into a file so it can be used in the next outer-iteration
-         call write_sl(topoxy, 'pred_pres_topo_', outputfolder, nglv, suffix=iterstr)
+         call write_sl(topoxy, 'pred_pres_topo_', outputfolder, suffix=iterstr)
 
          ! write out the initial topography of the simulation at the currect outer-loop into a file
-         call write_sl(tinit_0, 'tgrid0_', outputfolder, nglv, suffix=iterstr)
+         call write_sl(tinit_0, 'tgrid0_', outputfolder, suffix=iterstr)
        endif
 
       if (calcRG) then
-         call write_sl(rr(:,:,nfiles), 'R', outputfolder, nglv, suffix=numstr)
+         call write_sl(rr(:,:,nfiles), 'R', outputfolder, suffix=numstr)
 
          ! Compute geoid displacement and write out
          gg(:,:,nfiles) = deltaslxy(:,:)+rr(:,:,nfiles)
 
-         call write_sl(gg(:,:,nfiles), 'G', outputfolder, nglv, suffix=numstr)
+         call write_sl(gg(:,:,nfiles), 'G', outputfolder, suffix=numstr)
        endif
 
       if (coupling) then
          ! topography change between the previous and the current timestep
          ! this is the information passed to the ice sheet model
-         !call write_sl(topoxy_m1(:,:)-topoxy(:,:), 'bedrock', folder_coupled, nglv)
+         !call write_sl(topoxy_m1(:,:)-topoxy(:,:), 'bedrock', folder_coupled)
           slchange = topoxy_m1(:,:)-topoxy(:,:)
          !write out the current ice load as a new file
-         call write_sl(icexy(:,:,nfiles), icemodel_out, outputfolder_ice, nglv, suffix=numstr)
+         call write_sl(icexy(:,:,nfiles), icemodel_out, outputfolder_ice, suffix=numstr)
       endif !endif coupling
 
       call system_clock(countf) ! Total time

--- a/sl_model_mod.f90
+++ b/sl_model_mod.f90
@@ -534,6 +534,12 @@ module sl_model_mod
       !  write out the initial ocean function as a file
       call write_sl(cxy0(:,:), 'ocean', outputfolder, suffix=numstr)
 
+      ! write out the ocean area
+      call spat2spec(cxy0, clm, spheredat)
+      open(unit = 201, file = trim(outputfolder)//'ocean_area', form = 'formatted', access ='sequential', &
+      & status = 'replace')
+      write(201,'(ES14.4E2)') real(clm(0,0))*4*pi*radius**2
+      close(201)
 
       !========================== beta function =========================
       ! calculate initial beta
@@ -550,6 +556,13 @@ module sl_model_mod
       !  write out the initial beta function as a file
       call write_sl(beta0(:,:), 'beta', outputfolder, suffix=numstr)
 
+      ! write out the ocean area excluding the marine-based region
+      cstarxy(:,:) = cxy0(:,:) * beta0(:,:)
+      call spat2spec(cstarxy,cstarlm,spheredat)
+      open(unit = 201, file = trim(outputfolder)//'oceanBeta_area', form = 'formatted', access ='sequential', &
+      & status = 'replace')
+      write(201,'(ES14.4E2)') real(cstarlm(0,0))*4*pi*radius**2
+      close(201)
 
       !================== total ocean loading change =====================
       ! initialize the total ocean loading change and output as a file
@@ -1323,6 +1336,17 @@ module sl_model_mod
 
       ! converged beta function at the current timestpe
       call write_sl(beta, 'beta', outputfolder, suffix=numstr)
+
+      ! output the ocean areas
+      open(unit = 201, file = trim(outputfolder)//'ocean_area', form = 'formatted', access ='sequential', &
+      & status = 'old', position = 'append')
+      write(201,'(ES14.4E2)') real(clm(0,0))*4*pi*radius**2
+      close(201)
+
+      open(unit = 201, file = trim(outputfolder)//'oceanBeta_area', form = 'formatted', access ='sequential', &
+      & status = 'old', position = 'append')
+      write(201,'(ES14.4E2)') real(cstarlm(0,0))*4*pi*radius**2
+      close(201)
 
       ! output global mean sea level changes
       open(unit = 201, file = trim(outputfolder)//'gmslc_ocnArea', form = 'formatted', access ='sequential', &

--- a/sl_model_mod.f90
+++ b/sl_model_mod.f90
@@ -320,34 +320,6 @@ module sl_model_mod
       endif
 
       write(unit_num,*) 'HHHHH norder and nglv seen in the sl_timedow module', norder, nglv
-      ! Based on the calcualted number of files read in within the time window at each timestep,
-      ! allocate arrays to the below variables.
-      allocate (times(nfiles), lovebetatt(nfiles), lovebetattrr(nfiles))
-      allocate (lovebetarr(nfiles,norder),lovebeta(nfiles,norder))
-      allocate (icexy(nglv, 2*nglv, nfiles),sl(nglv,2*nglv,nfiles))
-      allocate (dS(0:norder,0:norder,nfiles),deltaS(0:norder,0:norder,nfiles))
-      allocate (dicestar(0:norder,0:norder,nfiles), deltaicestar(0:norder,0:norder,nfiles))
-      allocate (rr(nglv,2*nglv,nfiles),gg(nglv,2*nglv,nfiles))
-      allocate (dil(3,3,nfiles), dlambda(0:2,0:2,TW_nfiles),deltalambda(0:2,0:2,nfiles))
-      allocate (dm(3,nfiles))
-
-      times = 0.0
-      lovebetatt = 0.0
-      lovebetattrr = 0.0
-      lovebetarr = 0.0
-      lovebeta = 0.0
-      icexy = 0.0
-      sl = 0.0
-      dS = 0.0
-      deltaS = 0.0
-      dicestar = 0.0
-      deltaicestar = 0.0
-      rr = 0.0
-      gg = 0.0
-      dil = 0.0
-      dlambda = 0.0
-      deltalambda = 0.0
-      dm = 0.0
 
       !!!!!!!!!!!!!!!!!!!ATTENTION!!!!!!!!
       ! TIMEWINDOW = TIMEWINDOW+1
@@ -399,6 +371,17 @@ module sl_model_mod
                 dsllm(0:norder,0:norder), deltasllm(0:norder,0:norder), viscous(0:norder,0:norder), &
                 rrlm(0:norder,0:norder), dgglm(0:norder,0:norder), drrlm_computed(0:norder,0:norder), &
                 dS_converged(0:norder,0:norder))
+
+      ! Based on the calcualted number of files read in within the time window at each timestep,
+      ! allocate arrays to the below variables.
+      allocate (times(nfiles), lovebetatt(nfiles), lovebetattrr(nfiles))
+      allocate (lovebetarr(nfiles,norder),lovebeta(nfiles,norder))
+      allocate (icexy(nglv, 2*nglv, nfiles),sl(nglv,2*nglv,nfiles))
+      allocate (dS(0:norder,0:norder,nfiles),deltaS(0:norder,0:norder,nfiles))
+      allocate (dicestar(0:norder,0:norder,nfiles), deltaicestar(0:norder,0:norder,nfiles))
+      allocate (rr(nglv,2*nglv,nfiles),gg(nglv,2*nglv,nfiles))
+      allocate (dil(3,3,nfiles), dlambda(0:2,0:2,TW_nfiles),deltalambda(0:2,0:2,nfiles))
+      allocate (dm(3,nfiles))
 
       ! initialize the allocated arrays
       tinit_0 = 0.0
@@ -475,6 +458,24 @@ module sl_model_mod
       dgglm = 0.0
       drrlm_computed = 0.0
       dS_converged = 0.0
+
+      times = 0.0
+      lovebetatt = 0.0
+      lovebetattrr = 0.0
+      lovebetarr = 0.0
+      lovebeta = 0.0
+      icexy = 0.0
+      sl = 0.0
+      dS = 0.0
+      deltaS = 0.0
+      dicestar = 0.0
+      deltaicestar = 0.0
+      rr = 0.0
+      gg = 0.0
+      dil = 0.0
+      dlambda = 0.0
+      deltalambda = 0.0
+      dm = 0.0
 
    end subroutine sl_allocate_and_initialize_array
    !_______________________________________________________________________________________________________________________!

--- a/user_specs_mod.f90
+++ b/user_specs_mod.f90
@@ -60,6 +60,14 @@ module user_specs_mod
    ! 'folder_coupled' stores files that are exchanged between the ice (NHiceload) and sea level (bedrock) models. It is
    !  not used if the sea-level model (SLM) is not coupled to an ice sheet model (ISM)
 
+   ! Note: many of the items below are configurable in the 'namelist.sealevel' file. The use of the namelist file allows
+   ! the users to not have to re-compile the code when they change the options in the file. The options configurable
+   ! in the 'namelist.sealevel' files are the following: 'inputfolder_ice', 'inputfolder', 'planetfolder', 'gridfolder',
+   ! 'outputfolder', 'outputfolder_ice', 'folder_coupled', 'ext', 'fType_in', 'fType_out', 'planetmodel', 'icemodel',
+   ! 'icemodel_out', 'timearray', 'topomodel', 'topo_initial', 'grid_lat', 'grid_lon', 'checkmarine', 'tpw', 'calcRG',
+   ! 'input_times', 'initial_topo', 'iceVolume', 'coupling', 'patch_ice', 'norder', 'nglv', 'L_sim', 'dt1', 'dt2', 'dt3',
+   ! 'dt4', 'Ldt1', 'Ldt2', 'Ldt3', 'Ldt4'
+
    integer, parameter :: str_len = 200
    integer :: unit_num
 

--- a/user_specs_mod.f90
+++ b/user_specs_mod.f90
@@ -97,9 +97,9 @@ module user_specs_mod
    character(str_len) :: grid_lon       = 'GLlon_512.txt'           ! Grid file for longitude
    
    ! Model parameters==================================================================================================!
-   integer, parameter :: norder = 512           ! Max spherical harmonic degree/order
+   integer :: norder = 512                      ! Max spherical harmonic degree/order
+   integer :: nglv = 512                        ! Number of GL points in latitude
    integer, parameter :: npam = 500             ! Max relaxation modes
-   integer, parameter :: nglv = 512             ! Number of GL points in latitude
    real, parameter :: epsilon1 = 1.0E-5         ! Inner loop convergence criterion
    real, parameter :: epsilon2 = 1.0E-5         ! Outer loop convergence criterion 
                                                 !  (if doing a convergence check for outer loop, see below)


### PR DESCRIPTION
Previously, the variables `norder` and `nglv` were parameters defined in `users_specs_mod` module that
were used in declaring the dimension of many variables. This has raised
two issues in our recent efforts to run a suite of sensitivity coupled MALI-SLM
simulations that sweeps across various values of MALI mesh resolution
and the number of Gauss-Legendre nodes in latitude (named as variable `nglv`)
in the SLM. The first issue (or more like an inconvenience) is the need to code compilation needs to be done
everytime `nglv` parameter is changed, and the second is the failure
of compilation when the `nglv` value was set higher than 2000 because of limited memory imposed to the
variables that are declared with defined a dimension size.
This PR addresses the two issues by 1) no longer declaring the variables `norder` and `nglv` as
model parameters and instead making them public variables that can be read in from the namelist file, and 2) making the other variables that use `nglv` and `norder` to declare their dimension as allocatable.

Note 1: The changes on the MALI side that accomodate this PR is here: https://github.com/MALI-Dev/E3SM/pull/96
Note 2: This PR builds up on the first two commits that adds GMSLE calculation in the SLM.