### PR TITLE
Evaluate floating condition when calculating beta when marine check is on

### DIFF
--- a/sl_model_mod.f90
+++ b/sl_model_mod.f90
@@ -687,6 +687,8 @@ module sl_model_mod
                endif
             enddo
          enddo
+      else ! not checkmarine: use icexy unmodified
+         icestarxy(:,:) = icexy(:,:,1)
       endif
       ! calculate initial beta
       do j = 1,2*nglv
@@ -1091,6 +1093,7 @@ module sl_model_mod
       do n=1, nfiles
          ! Calculate icestar (STEP 3) (eq.43)
          if (checkmarine) then
+            write(unit_num,*) 'Performing Marine Check'
             do j = 1,2*nglv
                do i = 1,nglv
                   if (tinit(i,j) > 0) then

--- a/sl_model_mod.f90
+++ b/sl_model_mod.f90
@@ -671,10 +671,27 @@ module sl_model_mod
       close(201)
 
       !========================== beta function =========================
+      if (checkmarine) then
+         write(unit_num,*) 'Performing Marine Check for initial beta'
+         do j = 1,2*nglv
+            do i = 1,nglv
+               if (tinit_0(i,j) > 0) then
+               ! If not marine...
+                  icestarxy(i,j) = icexy(i,j,1)
+               elseif (icexy(i,j,1) > (abs(tinit_0(i,j)) * rhow / rhoi)) then
+               !...else if marine, but thick enough to be grounded
+                  icestarxy(i,j) = icexy(i,j,1)
+               else
+               !...if floating ice
+                  icestarxy(i,j) = 0.0
+               endif
+            enddo
+         enddo
+      endif
       ! calculate initial beta
       do j = 1,2*nglv
          do i = 1,nglv
-            if (icexy(i,j,1)==0) then
+            if (icestarxy(i,j) < epsilon(0.0)) then
                beta0(i,j)=1
             else
                beta0(i,j)=0
@@ -757,15 +774,15 @@ module sl_model_mod
                      icestarxy(i,j) = icexy(i,j,1)
                   else
                      !...if floating ice
-                     icestarxy(i,j) = 0
+                     icestarxy(i,j) = 0.0
                   endif
                enddo
             enddo
                   ! Decompose ice field
-            call spat2spec(icestarxy(:,:),icestarlm(:,:),spheredat)
          else ! If not checking for floating ice
-            call spat2spec(icexy(:,:,1),icestarlm(:,:),spheredat) ! Decompose ice field
+            icestarxy(:,:) = icexy(:,:,1)
          endif
+         call spat2spec(icestarxy(:,:),icestarlm(:,:),spheredat)
 
          ice_volume = icestarlm(0,0)*4*pi*radius**2
 
@@ -1084,15 +1101,15 @@ module sl_model_mod
                      icestarxy(i,j) = icexy(i,j,n)
                   else
                   !...if floating ice
-                     icestarxy(i,j) = 0
+                     icestarxy(i,j) = 0.0
                   endif
                enddo
             enddo
             ! Decompose ice field
-            call spat2spec(icestarxy(:,:),icestarlm(:,:),spheredat)
          else ! If not checking for floating ice
-            call spat2spec(icexy(:,:,n),icestarlm(:,:),spheredat) ! Decompose ice field
+            icestarxy(:,:) = icexy(:,:,n)
          endif
+         call spat2spec(icestarxy(:,:),icestarlm(:,:),spheredat)
 
          if (n == 1) then
             dicestarlm(:,:) = 0.0            ! No change at first timestep
@@ -1115,7 +1132,7 @@ module sl_model_mod
       ! Calculate current beta based on iceload at the current timestep
       do j = 1, 2 * nglv
          do i = 1, nglv
-             if (icexy(i, j, nfiles) < epsilon(0.0)) then
+             if (icestarxy(i,j) < epsilon(0.0)) then
                 beta(i,j) = 1
              else
                 beta(i,j) = 0


### PR DESCRIPTION
Previously, the marine check was adjusting the ice load for floating and grounded ice, but it was not applying the flotation condition when calculating beta.  This commit adds the flotation evaluation to beta.